### PR TITLE
add extras_require for installing test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
                 'This package is part of the Xsuite collection.'),
     url='https://xsuite.readthedocs.io/',
     packages=find_packages(),
-    ext_modules = extensions,
+    ext_modules=extensions,
     include_package_data=True,
     install_requires=[
         'numpy>=1.0',
@@ -39,5 +39,8 @@ setup(
             "Bug Tracker": "https://github.com/xsuite/xsuite/issues",
             "Documentation": 'https://xsuite.readthedocs.io/',
             "Source Code": "https://github.com/xsuite/xpart",
+        },
+    extras_require={
+        'tests': ['cpymad', 'PyHEADTAIL'],
         },
     )


### PR DESCRIPTION
With this, one can install xtrack for testing as following:
```bash
cd /path/to/xpart
pip install -e .[tests]  # will install cpymad and pyHEADTAIL if unavailable
```