### PR TITLE
Single RF Harmonic distribution matching

### DIFF
--- a/examples/longitudinal/example_separatrix.py
+++ b/examples/longitudinal/example_separatrix.py
@@ -1,0 +1,54 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+import time
+
+ctx = xo.ContextCpu()
+
+# Load machine model 
+filename = xt._pkg_root.parent.joinpath('test_data/sps_ions/line.json')
+#filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
+with open(filename, 'r') as fid:
+    input_data = json.load(fid)
+tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data))
+#tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data['line']))
+
+rms_bunch_length=0.14
+distribution = "gaussian"
+n_particles = 10000
+zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker,
+                                                 num_particles=n_particles,
+                                                 sigma_z=rms_bunch_length, distribution=distribution,
+                                                 engine="single-rf-harmonic", return_matcher=True)
+                                                 #engine="pyheadtail", return_matcher=True)
+    
+# Built a set of three particles with different x coordinates
+particles = xp.build_particles(_context=ctx,
+                               tracker=tracker,
+                               zeta=0., delta=np.linspace(0,0.0015, 30),
+                               x_norm=0, # in sigmas
+                               px_norm=0, # in sigmas
+                               scale_with_transverse_norm_emitt=(3e-6, 3e-6)
+                               )
+
+tracker.track(particles, num_turns=300, turn_by_turn_monitor=True)
+x_sep, y_sep = matcher.get_separatrix()
+plt.figure(1)
+plt.plot(tracker.record_last_track.zeta, tracker.record_last_track.delta, 'k.')
+plt.plot(x_sep, y_sep, 'r')
+plt.plot(x_sep, -y_sep, 'r')
+plt.xlim(-3,3)
+plt.xlabel('zeta [m]')
+plt.ylabel('delta')
+
+plt.show()

--- a/examples/longitudinal/example_single_rf_matching.py
+++ b/examples/longitudinal/example_single_rf_matching.py
@@ -1,0 +1,65 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+import time
+
+ctx = xo.ContextCpu()
+# Build a reference particle
+p0 = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12, x=1, y=3,
+                  delta=[10], _context=ctx)
+
+
+# Load machine model (from pymask)
+filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
+with open(filename, 'r') as fid:
+    input_data = json.load(fid)
+tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data['line']))
+
+rms_bunch_length=0.14
+distribution = "gaussian"
+n_particles = 1000000
+zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker, particle_ref=p0,
+                                                 num_particles=n_particles,
+                                                 sigma_z=rms_bunch_length, distribution=distribution,
+                                                 engine="single-rf-harmonic", return_matcher=True)
+                                                 #engine="pyheadtail", return_matcher=True)
+    
+# Built a set of three particles with different x coordinates
+particles = xp.build_particles(_context=ctx,
+                               tracker=tracker, particle_ref=p0,
+                               zeta=zeta, delta=delta,
+                               x_norm=0, # in sigmas
+                               px_norm=0, # in sigmas
+                               scale_with_transverse_norm_emitt=(3e-6, 3e-6)
+                               )
+
+x_sep, y_sep = matcher.get_separatrix()
+plt.figure(1)
+plt.hist2d(zeta, delta, bins=100, range=((-0.7,0.7), (-0.001, 0.001)), cmin=0.001)
+plt.plot(x_sep, y_sep, 'r')
+plt.plot(x_sep, -y_sep, 'r')
+plt.xlabel('zeta [m]')
+plt.ylabel('delta')
+
+tau_distr_y = matcher.tau_distr_y
+tau_distr_x = matcher.tau_distr_x
+dx = tau_distr_x[1] - tau_distr_x[0]
+hist, _  = np.histogram(zeta, range=(tau_distr_x[0]-dx/2., tau_distr_x[-1]+dx/2.), bins=len(tau_distr_x))
+hist = hist / sum(hist) * sum(tau_distr_y)
+plt.figure(2)
+plt.plot(tau_distr_x, hist, 'bo', label="sampled line density")
+plt.plot(tau_distr_x, tau_distr_y, 'r-', label="input line density")
+plt.xlabel('ζ [m]')
+plt.legend()
+
+plt.show()

--- a/examples/longitudinal/example_single_rf_matching_ions.py
+++ b/examples/longitudinal/example_single_rf_matching_ions.py
@@ -1,0 +1,62 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+import time
+
+ctx = xo.ContextCpu()
+
+# Load machine model (from pymask)
+filename = xt._pkg_root.parent.joinpath('test_data/sps_ions/line.json')
+with open(filename, 'r') as fid:
+    input_data = json.load(fid)
+tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data))
+
+rms_bunch_length=0.20
+distribution = "gaussian"
+n_particles = 1000000
+zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker,
+                                                 num_particles=n_particles,
+                                                 sigma_z=rms_bunch_length, distribution=distribution,
+                                                 engine="single-rf-harmonic", return_matcher=True)
+                                                 #engine="pyheadtail", return_matcher=True)
+    
+# Built a set of three particles with different x coordinates
+particles = xp.build_particles(_context=ctx,
+                               tracker=tracker,
+                               zeta=zeta, delta=delta,
+                               x_norm=0, # in sigmas
+                               px_norm=0, # in sigmas
+                               scale_with_transverse_norm_emitt=(3e-6, 3e-6)
+                               )
+
+x_sep, y_sep = matcher.get_separatrix()
+tau = zeta/tracker.line.particle_ref.beta0
+plt.figure(1)
+plt.hist2d(zeta, delta, bins=100, range=((-0.7,0.7), (-0.001, 0.001)), cmin=0.001)
+plt.plot(x_sep, y_sep, 'r')
+plt.plot(x_sep, -y_sep, 'r')
+plt.xlabel('zeta [m]')
+plt.ylabel('delta')
+
+tau_distr_y = matcher.tau_distr_y
+tau_distr_x = matcher.tau_distr_x
+dx = tau_distr_x[1] - tau_distr_x[0]
+hist, _  = np.histogram(tau, range=(tau_distr_x[0]-dx/2., tau_distr_x[-1]+dx/2.), bins=len(tau_distr_x))
+hist = hist / sum(hist) * sum(tau_distr_y)
+plt.figure(2)
+plt.plot(tau_distr_x, hist, 'bo', label="sampled line density")
+plt.plot(tau_distr_x, tau_distr_y, 'r-', label="input line density")
+plt.xlabel('ζ [m]')
+plt.legend()
+
+plt.show()

--- a/tests/test_single_rf_harmonic_matcher.py
+++ b/tests/test_single_rf_harmonic_matcher.py
@@ -5,7 +5,6 @@
 
 import json
 
-import matplotlib.pyplot as plt
 import numpy as np
 
 import xobjects as xo

--- a/tests/test_single_rf_harmonic_matcher.py
+++ b/tests/test_single_rf_harmonic_matcher.py
@@ -15,29 +15,40 @@ def test_single_rf_harmonic_matcher_rms_and_profile():
     for ctx in xo.context.get_test_contexts():
         print(f"Test {ctx.__class__}")
     
-        # Build a reference particle
-        p0 = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12, x=1, y=3,
-                          delta=[10], _context=ctx)
+        for type in ["ions",]:# "ions"]:
+            if type == "protons":
+                # Build a reference particle
+                p0 = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12, x=1, y=3,
+                                  delta=[10], _context=ctx)
     
+                # Load machine model (from pymask)
+                filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
+                with open(filename, 'r') as fid:
+                    input_data = json.load(fid)
+                tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data['line']))
+                tracker.line.particle_ref = p0 
+
+            elif type == "ions":
+                # Load machine model (spsio)
+                filename = xt._pkg_root.parent.joinpath('test_data/sps_ions/line.json')
+                with open(filename, 'r') as fid:
+                    input_data = json.load(fid)
+                tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data))
+            else:
+                raise NotImplementedError
+                
+            rms_bunch_length=0.10
+            for distribution in ["gaussian", "parabolic"]:
+                zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker, # particle_ref=p0,
+                                                                 num_particles=1000000,
+                                                                 sigma_z=rms_bunch_length, distribution=distribution,
+                                                                 engine="single-rf-harmonic", return_matcher=True)
+                tau = zeta / tracker.line.particle_ref.beta0
+                tau_distr_y = matcher.tau_distr_y
+                tau_distr_x = matcher.tau_distr_x
+                dx = tau_distr_x[1] - tau_distr_x[0]
+                hist, _  = np.histogram(tau, range=(tau_distr_x[0]-dx/2., tau_distr_x[-1]+dx/2.), bins=len(tau_distr_x))
+                hist = hist / sum(hist) * sum(tau_distr_y)
     
-        # Load machine model (from pymask)
-        filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
-        with open(filename, 'r') as fid:
-            input_data = json.load(fid)
-        tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data['line']))
-    
-        rms_bunch_length=0.10
-        for distribution in ["gaussian", "parabolic"]:
-            zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker, particle_ref=p0,
-                                                             num_particles=1000000,
-                                                             sigma_z=rms_bunch_length, distribution=distribution,
-                                                             engine="single-rf-harmonic", return_matcher=True)
-            
-            tau_distr_y = matcher.tau_distr_y
-            tau_distr_x = matcher.tau_distr_x
-            dx = tau_distr_x[1] - tau_distr_x[0]
-            hist, _  = np.histogram(zeta, range=(tau_distr_x[0]-dx/2., tau_distr_x[-1]+dx/2.), bins=len(tau_distr_x))
-            hist = hist / sum(hist) * sum(tau_distr_y)
-    
-            assert np.isclose(rms_bunch_length, np.std(zeta), rtol=1e-2, atol=1e-15)
-            assert np.all(np.isclose(hist, tau_distr_y, atol=3.e-2, rtol=1.e-2))
+                assert np.isclose(rms_bunch_length, np.std(tau), rtol=1e-2, atol=1e-15)
+                assert np.all(np.isclose(hist, tau_distr_y, atol=3.e-2, rtol=1.e-2))

--- a/tests/test_single_rf_harmonic_matcher.py
+++ b/tests/test_single_rf_harmonic_matcher.py
@@ -1,0 +1,44 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import xobjects as xo
+import xpart as xp
+import xtrack as xt
+
+def test_single_rf_harmonic_matcher_rms_and_profile():
+    for ctx in xo.context.get_test_contexts():
+        print(f"Test {ctx.__class__}")
+    
+        # Build a reference particle
+        p0 = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12, x=1, y=3,
+                          delta=[10], _context=ctx)
+    
+    
+        # Load machine model (from pymask)
+        filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
+        with open(filename, 'r') as fid:
+            input_data = json.load(fid)
+        tracker = xt.Tracker(_context=ctx, line=xt.Line.from_dict(input_data['line']))
+    
+        rms_bunch_length=0.10
+        for distribution in ["gaussian", "parabolic"]:
+            zeta, delta, matcher = xp.generate_longitudinal_coordinates(tracker=tracker, particle_ref=p0,
+                                                             num_particles=1000000,
+                                                             sigma_z=rms_bunch_length, distribution=distribution,
+                                                             engine="single-rf-harmonic", return_matcher=True)
+            
+            tau_distr_y = matcher.tau_distr_y
+            tau_distr_x = matcher.tau_distr_x
+            dx = tau_distr_x[1] - tau_distr_x[0]
+            hist, _  = np.histogram(zeta, range=(tau_distr_x[0]-dx/2., tau_distr_x[-1]+dx/2.), bins=len(tau_distr_x))
+            hist = hist / sum(hist) * sum(tau_distr_y)
+    
+            assert np.isclose(rms_bunch_length, np.std(zeta), rtol=1e-2, atol=1e-15)
+            assert np.all(np.isclose(hist, tau_distr_y, atol=3.e-2, rtol=1.e-2))

--- a/xpart/longitudinal/__init__.py
+++ b/xpart/longitudinal/__init__.py
@@ -4,3 +4,4 @@
 # ######################################### #
 
 from .generate_longitudinal import generate_longitudinal_coordinates
+from .single_rf_harmonic_matcher import SingleRFHarmonicMatcher

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -16,6 +16,7 @@ from .rfbucket_matching import ThermalDistribution
 from .rf_bucket import RFBucket
 from ..particles import Particles
 from .single_rf_harmonic_matcher import SingleRFHarmonicMatcher
+from ..constants import PROTON_MASS_EV 
 
 logger = logging.getLogger(__name__)
 
@@ -152,7 +153,7 @@ def generate_longitudinal_coordinates(
             raise NotImplementedError
 
         # if not a proton
-        if q0 != 1.0 or particle_ref.chi != 1.0 or abs(mass0 - 938272088) > 1.:
+        if q0 != 1.0 or particle_ref.chi != 1.0 or abs(mass0 - PROTON_MASS_EV) > 1.:
             raise NotImplementedError
 
         sigma_tau = sigma_z/particle_ref.beta0[0]

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -68,11 +68,8 @@ def generate_longitudinal_coordinates(
                                     p_increment=0.,
                                     distribution='gaussian',
                                     sigma_z=None,
-<<<<<<< HEAD
+                                    engine="pyheadtail",
                                     **kwargs # passed to twiss
-=======
-                                    engine="pyheadtail"
->>>>>>> d9a79b9 (bring characterize tracker outside and correct bunch length)
                                     ):
 
     if tracker is not None:
@@ -163,15 +160,15 @@ def generate_longitudinal_coordinates(
         voltage = np.sum(rf_voltage)
 
         harmonic_number = np.round(rf_harmonic).astype(int)[0]
-        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-2, rtol=0.):
+        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-10, rtol=0.):
             raise Exception(f"Multiple harmonics detected in lattice: {rf_harmonic}")
 
-        matcher = SingleRFHarmonicMatcher(voltage=voltage,
+        matcher = SingleRFHarmonicMatcher(voltage=voltage, 
                                           length=circumference,
                                           freq=dct['freq_list'][0],
                                           p0c=particle_ref.p0c[0],
                                           slip_factor=eta,
-                                          rms_bunch_length=sigma_tau,
+                                          rms_bunch_length=sigma_tau, 
                                           distribution=distribution)
 
         tau, ptau = matcher.sample_tau_ptau(n_particles=num_particles)

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -14,6 +14,8 @@ import xobjects as xo
 from .rfbucket_matching import RFBucketMatcher
 from .rfbucket_matching import ThermalDistribution
 from .rf_bucket import RFBucket
+from ..particles import Particles
+from .single_rf_harmonic_matcher import SingleRFHarmonicMatcher
 
 logger = logging.getLogger(__name__)
 
@@ -66,7 +68,11 @@ def generate_longitudinal_coordinates(
                                     p_increment=0.,
                                     distribution='gaussian',
                                     sigma_z=None,
+<<<<<<< HEAD
                                     **kwargs # passed to twiss
+=======
+                                    engine="pyheadtail"
+>>>>>>> d9a79b9 (bring characterize tracker outside and correct bunch length)
                                     ):
 
     if tracker is not None:
@@ -105,35 +111,74 @@ def generate_longitudinal_coordinates(
         assert tracker is not None
         rf_phase=(np.array(dct['lag_list_deg']) - 180)/180*np.pi
 
-    if distribution != 'gaussian':
-        raise NotImplementedError
 
     assert sigma_z is not None
-    rfbucket = RFBucket(circumference=circumference,
-                        gamma=gamma0,
-                        mass_kg=mass0/(clight**2)*qe,
-                        charge_coulomb=np.abs(q0)*qe,
-                        alpha_array=np.atleast_1d(momentum_compaction_factor),
-                        harmonic_list=np.atleast_1d(rf_harmonic),
-                        voltage_list=np.atleast_1d(rf_voltage),
-                        phi_offset_list=np.atleast_1d(rf_phase),
-                        p_increment=p_increment)
 
-    if sigma_z < 0.1 * circumference/np.max(np.atleast_1d(rf_harmonic)):
-        logger.info('short bunch, use linear matching')
+    if engine == "pyheadtail":
+        if distribution != 'gaussian':
+            raise NotImplementedError
+
+        rfbucket = RFBucket(circumference=circumference,
+                            gamma=gamma0,
+                            mass_kg=mass0/(clight**2)*qe,
+                            charge_coulomb=np.abs(q0)*qe,
+                            alpha_array=np.atleast_1d(momentum_compaction_factor),
+                            harmonic_list=np.atleast_1d(rf_harmonic),
+                            voltage_list=np.atleast_1d(rf_voltage),
+                            phi_offset_list=np.atleast_1d(rf_phase),
+                            p_increment=p_increment)
+
+        if sigma_z < 0.1 * circumference/np.max(np.atleast_1d(rf_harmonic)):
+            logger.info('short bunch, use linear matching')
+            eta = momentum_compaction_factor - 1/particle_ref._xobject.gamma0[0]**2
+            beta_z = np.abs(eta) * circumference / 2.0 / np.pi / rfbucket.Q_s
+            sigma_dp = sigma_z / beta_z
+
+            z_particles = sigma_z * np.random.normal(size=num_particles)
+            delta_particles = sigma_dp * np.random.normal(size=num_particles)
+
+        else:
+            # Generate longitudinal coordinates
+            matcher = RFBucketMatcher(rfbucket=rfbucket,
+                distribution_type=ThermalDistribution,
+                sigma_z=sigma_z)
+            z_particles, delta_particles, _, _ = matcher.generate(
+                                                    macroparticlenumber=num_particles)
+    elif engine == "single-rf-harmonic":
+        if distribution not in ["parabolic", "gaussian"]:
+            raise NotImplementedError
+        
         eta = momentum_compaction_factor - 1/particle_ref._xobject.gamma0[0]**2
-        beta_z = np.abs(eta) * circumference / 2.0 / np.pi / rfbucket.Q_s
-        sigma_dp = sigma_z / beta_z
 
-        z_particles = sigma_z * np.random.normal(size=num_particles)
-        delta_particles = sigma_dp * np.random.normal(size=num_particles)
+        # if below transition
+        if eta < 0:
+            raise NotImplementedError
 
-    else:
-        # Generate longitudinal coordinates
-        matcher = RFBucketMatcher(rfbucket=rfbucket,
-            distribution_type=ThermalDistribution,
-            sigma_z=sigma_z)
-        z_particles, delta_particles, _, _ = matcher.generate(
-                                                macroparticlenumber=num_particles)
+        # if not a proton
+        if q0 != 1.0 or particle_ref.chi != 1.0 or abs(mass0 - 938272088) > 1.:
+            raise NotImplementedError
+
+        sigma_tau = sigma_z/particle_ref.beta0[0]
+
+        voltage = np.sum(rf_voltage)
+
+        harmonic_number = np.round(rf_harmonic).astype(int)[0]
+        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-10, rtol=0.):
+            raise Exception(f"Multiple harmonics detected in lattice: {rf_harmonic}")
+
+        matcher = SingleRFHarmonicMatcher(voltage=voltage, 
+                                          length=circumference,
+                                          freq=dct['freq_list'][0],
+                                          p0c=particle_ref.p0c[0],
+                                          slip_factor=eta,
+                                          rms_bunch_length=sigma_tau, 
+                                          distribution=distribution)
+
+        tau, ptau = matcher.sample_tau_ptau(n_particles=num_particles)
+
+        # convert (tau, ptau) to (zeta, delta)
+        z_particles = np.array(particle_ref.beta0[0]) * np.array(tau)  # zeta
+        temp_particles = Particles(p0c=particle_ref.p0c, zeta=z_particles, ptau=ptau)
+        delta_particles = np.array(temp_particles.delta)
 
     return z_particles, delta_particles

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -163,15 +163,15 @@ def generate_longitudinal_coordinates(
         voltage = np.sum(rf_voltage)
 
         harmonic_number = np.round(rf_harmonic).astype(int)[0]
-        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-10, rtol=0.):
+        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-2, rtol=0.):
             raise Exception(f"Multiple harmonics detected in lattice: {rf_harmonic}")
 
-        matcher = SingleRFHarmonicMatcher(voltage=voltage, 
+        matcher = SingleRFHarmonicMatcher(voltage=voltage,
                                           length=circumference,
                                           freq=dct['freq_list'][0],
                                           p0c=particle_ref.p0c[0],
                                           slip_factor=eta,
-                                          rms_bunch_length=sigma_tau, 
+                                          rms_bunch_length=sigma_tau,
                                           distribution=distribution)
 
         tau, ptau = matcher.sample_tau_ptau(n_particles=num_particles)

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -70,6 +70,7 @@ def generate_longitudinal_coordinates(
                                     distribution='gaussian',
                                     sigma_z=None,
                                     engine="pyheadtail",
+                                    return_matcher=False,
                                     **kwargs # passed to twiss
                                     ):
 
@@ -152,8 +153,8 @@ def generate_longitudinal_coordinates(
         if eta < 0:
             raise NotImplementedError
 
-        # if not a proton
-        if q0 != 1.0 or particle_ref.chi != 1.0 or abs(mass0 - PROTON_MASS_EV) > 1.:
+        # if fragment
+        if particle_ref.chi != 1.0:
             raise NotImplementedError
 
         sigma_tau = sigma_z/particle_ref.beta0[0]
@@ -161,10 +162,11 @@ def generate_longitudinal_coordinates(
         voltage = np.sum(rf_voltage)
 
         harmonic_number = np.round(rf_harmonic).astype(int)[0]
-        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-10, rtol=0.):
+        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-2, rtol=0.):
             raise Exception(f"Multiple harmonics detected in lattice: {rf_harmonic}")
 
-        matcher = SingleRFHarmonicMatcher(voltage=voltage, 
+        matcher = SingleRFHarmonicMatcher(q0=q0,
+                                          voltage=voltage,
                                           length=circumference,
                                           freq=dct['freq_list'][0],
                                           p0c=particle_ref.p0c[0],
@@ -179,4 +181,7 @@ def generate_longitudinal_coordinates(
         temp_particles = Particles(p0c=particle_ref.p0c, zeta=z_particles, ptau=ptau)
         delta_particles = np.array(temp_particles.delta)
 
-    return z_particles, delta_particles
+    if return_matcher:
+        return z_particles, delta_particles, matcher
+    else:
+        return z_particles, delta_particles

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -149,10 +149,6 @@ def generate_longitudinal_coordinates(
         
         eta = momentum_compaction_factor - 1/particle_ref._xobject.gamma0[0]**2
 
-        # if below transition
-        if eta < 0:
-            raise NotImplementedError
-
         # if fragment
         if particle_ref.chi != 1.0:
             raise NotImplementedError

--- a/xpart/longitudinal/generate_longitudinal.py
+++ b/xpart/longitudinal/generate_longitudinal.py
@@ -75,8 +75,12 @@ def generate_longitudinal_coordinates(
                                     ):
 
     if tracker is not None:
+        if particle_ref is None:
+            particle_ref = tracker.line.particle_ref 
         assert particle_ref is not None
         dct = _characterize_tracker(tracker, particle_ref, **kwargs)
+
+    assert particle_ref is not None
 
     if mass0 is None:
         assert particle_ref is not None
@@ -158,7 +162,7 @@ def generate_longitudinal_coordinates(
         voltage = np.sum(rf_voltage)
 
         harmonic_number = np.round(rf_harmonic).astype(int)[0]
-        if not np.allclose(harmonic_number, rf_harmonic, atol=1.e-2, rtol=0.):
+        if not np.allclose(harmonic_number, rf_harmonic, atol=5.e-1, rtol=0.):
             raise Exception(f"Multiple harmonics detected in lattice: {rf_harmonic}")
 
         matcher = SingleRFHarmonicMatcher(q0=q0,

--- a/xpart/longitudinal/single_rf_harmonic_matcher.py
+++ b/xpart/longitudinal/single_rf_harmonic_matcher.py
@@ -10,6 +10,7 @@ import scipy.special
 
 class SingleRFHarmonicMatcher:
     def __init__(self,
+                 q0=None,
                  voltage=None,
                  length=None,
                  freq=None,
@@ -24,7 +25,7 @@ class SingleRFHarmonicMatcher:
 
         # Hamoltonian: H = A cos(B tau) - C ptau^2
         # normalized Hamiltonian: m = ( sin(B/2*tau) )^2 + C/(2A) ptau^ 2
-        self.A = voltage/(2.*np.pi*freq*p0c/c*length)
+        self.A = q0*voltage/(2.*np.pi*freq*p0c/c*length)
         self.B = 2*np.pi*freq/c
         self.C = slip_factor/2.
 

--- a/xpart/longitudinal/single_rf_harmonic_matcher.py
+++ b/xpart/longitudinal/single_rf_harmonic_matcher.py
@@ -1,0 +1,154 @@
+import numpy as np
+from scipy.constants import c
+import scipy.special
+
+from .generate_longitudinal import _characterize_tracker
+
+class SingleRFHarmonicMatcher:
+    def __init__(self, tracker=None, particle_ref=None,
+                 rms_bunch_length=None, distribution="parabolic",
+                 transformation_particles=400000, verbose=0):
+
+        assert tracker is not None
+        assert particle_ref is not None
+        
+        self.verbose = verbose
+        self.transformation_particles = transformation_particles
+
+        dct = _characterize_tracker(tracker, particle_ref)
+        atol = 1.e-10
+        voltage_list = dct["voltage_list"]
+        ## mean_voltage = np.mean(voltage_list)
+        ## if not np.allclose(mean_voltage, voltage_list, atol=atol, rtol=0.):
+        ##     raise Exception(f"Multiple harmonics detected in lattice: {voltage_list}")
+
+        harmonic_list = dct["h_list"]
+        harmonic_number = np.round(harmonic_list).astype(int)[0]
+        if not np.allclose(harmonic_number, harmonic_list, atol=atol, rtol=0.):
+            raise Exception(f"Multiple harmonics detected in lattice: {harmonic_list}")
+
+        freq = dct['freq_list'][0]
+        length = harmonic_number * particle_ref.beta0[0] * c / freq
+        p0c_eV = particle_ref.p0c[0]
+        V0 = np.sum(voltage_list)
+        eta = dct['slip_factor']
+
+        # Hamoltonian: H = A cos(B tau) - C ptau^2
+        # normalized Hamiltonian: m = ( sin(B/2*tau) )^2 + C/(2A) ptau^ 2
+        self.A = V0/(2.*np.pi*freq*p0c_eV/c*length)
+        self.B = 2*np.pi*freq/c
+        self.C = eta/2.
+
+        tau_ufp = self.get_unstable_fixed_point()
+        dtau = 0.01*tau_ufp # don't get too close to the separatrix
+        if distribution == "parabolic":
+            tau_max = np.sqrt(5)*rms_bunch_length
+            self.tau_distr_x = np.linspace(- tau_ufp + dtau, tau_ufp - dtau, 300)
+            self.tau_distr_y = 1 - (self.tau_distr_x/tau_max)**2
+            self.tau_distr_y[abs(self.tau_distr_x) > tau_max] = 0
+            if tau_max >= tau_ufp:
+                print(f"WARNING SingleRFHarmonicMatcher: longitudinal profile larger than bucket, truncating to unstable fixed point. tau_max = {tau_max:.4f}, tau_ufp = {tau_ufp:.4f} ")
+        elif distribution == "gaussian":
+            self.tau_distr_x = np.linspace(- tau_ufp + dtau, tau_ufp - dtau, 300)
+            self.tau_distr_y = np.exp(-self.tau_distr_x**2/2./rms_bunch_length**2)
+        else:
+            raise NotImplementedError
+
+        self.m_distr_x, self.m_distr_y = self.transform_tau_distr_to_m_distr()
+
+
+    def transform_tau_distr_to_m_distr(self):
+        xp = self.tau_distr_x.copy()
+        yp = self.tau_distr_y.copy()
+        N = int(len(xp)/2.)
+        dx = xp[1] - xp[0]
+        m_distr_x = []
+        m_distr_y = []
+        for ii in range(N):
+            jj = len(xp) - ii - 1 #start from end
+            tau = xp[jj]
+            dens = yp[jj]
+            if dens == 0.:
+                continue
+            if self.verbose:
+                print(f"tau = {tau:.3f}, f(tau) = {dens:.3f}")
+            
+            m0 = self.get_m(tau=tau - dx/2.)
+            m1 = self.get_m(tau=tau + dx/2.)
+            dm = m1 - m0
+            m = self.get_m(tau=tau)
+            if m == 1.0:
+                continue
+            print('SingleRFHarmonicMatcher: Transforming distribution: '
+                        f'{round(ii/N*100):2d}%  ',end="\r", flush=True)
+            tau_test, ptau_test = self.get_airbag_from_m(m=m, n_particles=self.transformation_particles)
+            hist, bin_edges = np.histogram(tau_test, bins=len(xp), range=(min(xp)-dx/2., max(xp)+dx/2.))
+        
+            hist = (hist + hist[::-1])/2.
+            factor = dens/hist[jj]
+            yp -= hist*factor
+            m_distr_x.append(m)
+            m_distr_y.append(np.sum(hist)*factor/dm)
+
+        m_distr_x.append(0)
+        m_distr_y.append(0)
+        m_distr_x = m_distr_x[::-1]
+        m_distr_y = m_distr_y[::-1]
+
+        print('SingleRFHarmonicMatcher: Done transforming distribution.')
+        return m_distr_x, m_distr_y
+
+
+    def get_separatrix(self):
+        ufp = self.get_unstable_fixed_point()
+        xx = np.linspace(-ufp,ufp, 1000)
+        yy = np.sqrt(2*self.A/self.C) * np.cos(self.B/2.*xx)
+        return xx, yy
+
+    def get_unstable_fixed_point(self):
+        return np.pi/self.B
+
+    def get_m(self, tau=0, ptau=0):
+        return ( np.sin(self.B/2. * tau) )**2 + self.C / 2. / self.A * (ptau ** 2)
+
+    def get_airbag_from_m(self, m, n_particles=20000):
+        if n_particles is None:
+            n_particles = len(m)
+
+        K = scipy.special.ellipk(m)
+        G = 2.*K/np.pi
+        theta = np.random.uniform(size=n_particles)*2.*np.pi
+        sn, cn, dn, ph = scipy.special.ellipj(G*theta,m)
+    
+        tau = 2./self.B*np.arcsin(np.sqrt(m)*sn)
+        ptau = np.sqrt(2*self.A*m/self.C)*cn
+    
+        return tau, ptau
+
+    def sample_tau_ptau(self, n_particles=20000):
+        max_m = max(self.m_distr_x)
+        tau_new = []
+        ptau_new = []
+        counter = 0
+        max_y = np.max(self.m_distr_y)
+        chunk = 20000
+        ### Acceptance-rejection algorithm sampling from distribution of m and a random "angle"
+        ### The random angle is the conjugate variable to the action variable and is only
+        ### approximately equal to the angle in the tau-ptau space. 
+        while counter < n_particles:
+            m = np.random.random(size=chunk)*max_m
+            rand_test = np.random.random(size=chunk)*max_y
+            yy = np.interp(m, self.m_distr_x, self.m_distr_y)
+            
+            tau, ptau = self.get_airbag_from_m(m, n_particles=None)
+            
+            mask = rand_test < yy
+        
+            tau_new.extend(list(tau[mask]))
+            ptau_new.extend(list(ptau[mask]))
+            counter += sum(mask)
+            print('SingleRFHarmonicMatcher: Sampling particles: '
+                        f'{round(counter/n_particles*100):2d}%  ',end="\r", flush=True)
+        print(f"SingleRFHarmonicMatcher: Sampled {n_particles} particles")
+        
+        return tau_new[:n_particles], ptau_new[:n_particles]

--- a/xpart/longitudinal/single_rf_harmonic_matcher.py
+++ b/xpart/longitudinal/single_rf_harmonic_matcher.py
@@ -27,7 +27,10 @@ class SingleRFHarmonicMatcher:
         # normalized Hamiltonian: m = ( sin(B/2*tau) )^2 + C/(2A) ptau^ 2
         self.A = q0*voltage/(2.*np.pi*freq*p0c/c*length)
         self.B = 2*np.pi*freq/c
-        self.C = slip_factor/2.
+        self.C = abs(slip_factor)/2.
+        # the difference between above and below transition is that the Hamiltonian flips sign
+        # (considering always the absolute value of the slip factor)a. This is the same as if
+        # the particle goes back in turns. For the purpose of matching, this is of no concern. 
 
         tau_ufp = self.get_unstable_fixed_point()
         dtau = 0.01*tau_ufp # don't get too close to the separatrix


### PR DESCRIPTION
Asking for xpart to generate longitudinal coordinates with an rms bunch length of 0.14 m returns an error.

This new single-rf-harmonic matcher, will find a distribution of particles that when projected into the zeta variable, it will return the input longitudinal profile of the bunch.

```
zeta, delta = xp.generate_longitudinal_coordinates(tracker=tracker, particle_ref=p0,
                                                 num_particles=1000000,
                                                 sigma_z=0.14, distribution="gaussian",
                                                 engine="single-rf-harmonic")
```

***Gaussian and parabolic distributions of any rms bunch length are available but the module can easily be extended to allow any custom distribution.***

example:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/23062847/193840050-083bb2ee-8efc-4bbb-95d8-6e87f6075985.png"> <img width="376" alt="image" src="https://user-images.githubusercontent.com/23062847/193839952-c583cf21-1f88-4c92-80dc-bed890e68825.png">

The matching method uses the Jacobi elliptic functions which were originally defined as the solution to the pendulum problem, which is directly equivalent to the problem of a synchrotron oscillation in a system with a single RF harmonic.
***No approximations are made.*** No intensity effects are included i.e. no space charge effects, potential-well distortion e.t.c. It works by decomposing the input longitudinal profile into a sum of rings ("airbag distributions") to find the distribution in the Hamiltonian variable. It then samples from the computed Hamiltonian distribution with correct angle variables to generate zeta, delta coordinates. 

The default generation of particles is unchanged and specific instruction is needed to use this mode of generating particles.