### PR TITLE
pzeta property in particles

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -40,6 +40,12 @@ def _check_consistency_energy_variables(particles):
     assert np.allclose(particles.ptau, (energy - particles.energy0)/particles.p0c,
                        rtol=1e-14, atol=1e-14)
 
+    # Check consistency of pzeta
+    energy = particles.mass0 * gamma
+    assert np.allclose(particles.pzeta, (energy - particles.energy0)/(particles.beta0 * particles.p0c),
+                       rtol=1e-14, atol=1e-14)
+
+
     # Check energy property
     assert np.allclose(particles.energy, energy, rtol=1e-14, atol=1e-14)
 

--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -747,6 +747,13 @@ class Particles(xo.HybridClass):
                                             energy, mode='readonly',
                                             container=self)
 
+    @property
+    def pzeta(self):
+        pzeta = self.ptau / self.beta0
+        return self._buffer.context.linked_array_type.from_array(
+                                            pzeta, mode='readonly',
+                                            container=self)
+
     def add_to_energy(self, delta_energy):
         beta0 = self.beta0.copy()
         delta_beta0 = self.delta * beta0

--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -102,7 +102,7 @@ class Particles(xo.HybridClass):
              - rvv [1]:  beta / beta0
              - rpp [1]:  m/m0 P0c / Pc = 1/(1+delta)
              - zeta [m]:  (s - beta0 c t )
-             - tau [m]: (s - ct)
+             - tau [m]: (s / beta0 - ct)
              - mass0 [eV]: Reference rest mass
              - q0 [e]:  Reference charge
              - p0c [eV]: Reference momentum


### PR DESCRIPTION
## Description
Implemented pzeta property as read-only mode in the Particles object in order to have access to a pair of conjugate variables.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
