### PR TITLE
retry flaky tests

### DIFF
--- a/tests/test_single_rf_harmonic_matcher.py
+++ b/tests/test_single_rf_harmonic_matcher.py
@@ -11,6 +11,10 @@ import xobjects as xo
 import xpart as xp
 import xtrack as xt
 
+from xpart.test_helpers import retry
+
+
+@retry(on=AssertionError, n_times=3)
 def test_single_rf_harmonic_matcher_rms_and_profile():
     for ctx in xo.context.get_test_contexts():
         print(f"Test {ctx.__class__}")

--- a/tests/test_testlib.py
+++ b/tests/test_testlib.py
@@ -1,0 +1,22 @@
+import random
+import pytest
+
+from xpart.test_helpers import retry
+
+
+@retry(on=AssertionError, n_times=100)
+def test_retry_passes():
+    """Below assertion almost always fails, however the test should
+    practically always pass (1 in 38k chance of failure)."""
+    assert random.random() > 0.9
+
+
+def test_retry_fails():
+    @retry(on=AssertionError, n_times=2)
+    def actual_test():
+        """Below assertion practically always fails, thus the test is
+        expected to fail as well after only 2 runs."""
+        assert random.random() > 0.99_999
+
+    with pytest.raises(AssertionError):
+        actual_test()

--- a/xpart/test_helpers.py
+++ b/xpart/test_helpers.py
@@ -1,0 +1,23 @@
+from functools import wraps
+from typing import Tuple, Type, Union
+
+
+def retry(on: Union[Type[Exception], Tuple[Type[Exception]]],
+          n_times: int = 3):
+    """
+    A decorator to be used on a flaky test. The test will be rerun until no
+    exception defined in `on` is thrown, up to `n_times`.
+    """
+    def decorator(test_function):
+        @wraps(test_function)
+        def wrapper(*args, **kwargs):
+            for i in range(n_times):
+                try:
+                    return test_function(*args, **kwargs)
+                except on as e:
+                    if i + 1 < n_times:
+                        continue
+                    else:
+                        raise e
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Description

Add a decorator that will rerun flaky tests given certain conditions.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
