### PR TITLE
freeze variables with C flags

### DIFF
--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -189,7 +189,7 @@ class Particles(xo.HybridClass):
                     {kk: kwargs['_capacity'] for tt, kk in per_particle_vars})
 
             if 'pzeta' in kwargs.keys():
-                del(kwargs['pzeta']) # handled in part_dict
+                del(kwargs['pzeta'])  # handled in part_dict
 
             if 'sigma' in kwargs.keys():
                 raise NameError(
@@ -796,7 +796,8 @@ def _str_in_list(string, str_list):
 def part_energy_varnames():
     return [vv for tt, vv in part_energy_vars]
 
-def gen_local_particle_api(mode='no_local_copy', freeze_vars=()):
+
+def gen_local_particle_api(mode='no_local_copy'):
 
     if mode != 'no_local_copy':
         raise NotImplementedError
@@ -868,11 +869,9 @@ def gen_local_particle_api(mode='no_local_copy', freeze_vars=()):
     /*gpufun*/
     void LocalParticle_add_to_'''+vv+f'(LocalParticle* part, {tt._c_type} value)'
     +'{')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('/* frozen variable!')
+        src_lines.append(f'#ifndef FREEZE_VAR_{vv}')
         src_lines.append(f'  part->{vv}[part->ipart] += value;')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('frozen variable!*/')
+        src_lines.append('#endif')
         src_lines.append('}\n')
     src_adders = '\n'.join(src_lines)
 
@@ -883,11 +882,9 @@ def gen_local_particle_api(mode='no_local_copy', freeze_vars=()):
     /*gpufun*/
     void LocalParticle_scale_'''+vv+f'(LocalParticle* part, {tt._c_type} value)'
     +'{')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('/* frozen variable!')
+        src_lines.append(f'#ifndef FREEZE_VAR_{vv}')
         src_lines.append(f'  part->{vv}[part->ipart] *= value;')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('frozen variable!*/')
+        src_lines.append('#endif')
         src_lines.append('}\n')
     src_scalers = '\n'.join(src_lines)
 
@@ -898,11 +895,9 @@ def gen_local_particle_api(mode='no_local_copy', freeze_vars=()):
     /*gpufun*/
     void LocalParticle_set_'''+vv+f'(LocalParticle* part, {tt._c_type} value)'
     +'{')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('/* frozen variable!')
+        src_lines.append(f'#ifndef FREEZE_VAR_{vv}')
         src_lines.append(f'  part->{vv}[part->ipart] = value;')
-        if _str_in_list(vv, freeze_vars):
-            src_lines.append('frozen variable!*/')
+        src_lines.append('#endif')
         src_lines.append('}')
     src_setters = '\n'.join(src_lines)
 

--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -156,7 +156,8 @@ class Particles(xo.HybridClass):
             'scalar_vars': scalar_vars,
             'per_particle_vars': per_particle_vars}
 
-    def __init__(self,**kwargs):
+    def __init__(self, **kwargs):
+
 
         input_kwargs = kwargs.copy()
 
@@ -233,8 +234,8 @@ class Particles(xo.HybridClass):
                             value = 0.
                         getattr(self, kk)[:] = value
 
-            self._num_active_particles = -1 # To be filled in only on CPU
-            self._num_lost_particles = -1 # To be filled in only on CPU
+            self._num_active_particles = -1  # To be filled in only on CPU
+            self._num_lost_particles = -1  # To be filled in only on CPU
 
             # Force values provided by user if compatible
             for nn in part_energy_varnames():
@@ -259,7 +260,7 @@ class Particles(xo.HybridClass):
                 else:
                     self.reorganize()
 
-    def init_pipeline(self,name):
+    def init_pipeline(self, name):
         self.name = name
 
     def to_dict(self, copy_to_cpu=True,
@@ -279,7 +280,7 @@ class Particles(xo.HybridClass):
             remove_redundant_variables = compact
 
         if keep_rng_state is None:
-            keep_rng_state = not(compact)
+            keep_rng_state = not compact
 
         p_for_dict = self
 
@@ -350,8 +351,8 @@ class Particles(xo.HybridClass):
         # Check that scalar variable are compatible
         for tt, nn in scalar_vars:
             vals = [getattr(pp, nn) for pp in cpu_lst]
-            assert np.allclose(vals,
-                                getattr(cpu_lst[0], nn), rtol=0, atol=1e-14)
+            assert np.allclose(vals, getattr(cpu_lst[0], nn),
+                               rtol=0, atol=1e-14)
 
         # Make new particle on CPU
         capacity = np.sum([pp._capacity for pp in cpu_lst])
@@ -413,8 +414,8 @@ class Particles(xo.HybridClass):
 
             # Pyopencl returns int8 instead of bool
             if (isinstance(self._buffer.context, xo.ContextPyopencl) and
-                mask.dtype==np.int8):
-                assert np.all((mask>=0) & (mask<=1))
+                    mask.dtype == np.int8):
+                assert np.all((mask >= 0) & (mask <= 1))
                 mask = mask > 0
 
         # Make new particle on CPU
@@ -464,7 +465,7 @@ class Particles(xo.HybridClass):
 
         if seeds is None:
             seeds = np.random.randint(low=1, high=4e9,
-                        size=self._capacity, dtype=np.uint32)
+                                      size=self._capacity, dtype=np.uint32)
         else:
             assert len(seeds) == self._capacity
             if not hasattr(seeds, 'dtype') or seeds.dtype != np.uint32:
@@ -473,7 +474,7 @@ class Particles(xo.HybridClass):
         context = self._buffer.context
         seeds_dev = context.nparray_to_context_array(seeds)
         context.kernels.Particles_initialize_rand_gen(particles=self,
-             seeds=seeds_dev, n_init=self._capacity)
+            seeds=seeds_dev, n_init=self._capacity)
 
     def hide_lost_particles(self, _assume_reorganized=False):
         self._lim_arrays_name = '_num_active_particles'
@@ -503,7 +504,7 @@ class Particles(xo.HybridClass):
 
         n_used = n_active + n_lost
         sort_key_var = getattr(self, by)[:n_used].copy()
-        if not(interleave_lost_particles):
+        if not interleave_lost_particles:
             max_id_active = np.max(self.particle_id[:n_active])
             sort_key_var[n_active:] = 10 + max_id_active + sort_key_var[n_active:]
 
@@ -606,7 +607,6 @@ class Particles(xo.HybridClass):
         else:
             return ctx.nplike_lib.any(self.state <= 0)
 
-
     def update_delta(self, new_delta_value):
 
         ctx = self._buffer.context
@@ -627,10 +627,10 @@ class Particles(xo.HybridClass):
 
         new_delta_beta0 = new_delta_value * beta0
         new_ptau_beta0 = (new_delta_beta0 * new_delta_beta0
-                        + 2. * new_delta_beta0 * beta0 + 1.)**0.5 - 1.
+                          + 2. * new_delta_beta0 * beta0 + 1.)**0.5 - 1.
 
         new_one_plus_delta = 1. + new_delta_value
-        new_rvv = ( new_one_plus_delta ) / ( 1. + new_ptau_beta0 )
+        new_rvv = new_one_plus_delta / (1. + new_ptau_beta0)
         new_rpp = 1. / new_one_plus_delta
         new_ptau = new_ptau_beta0 / beta0
 
@@ -644,7 +644,6 @@ class Particles(xo.HybridClass):
             self._rvv = new_rvv
             self._ptau = new_ptau
             self._rpp = new_rpp
-
 
     @property
     def delta(self):
@@ -686,12 +685,12 @@ class Particles(xo.HybridClass):
             zeta = self.zeta
 
         ptau = new_ptau
-        irpp = (ptau*ptau + 2*ptau/beta0 +1)**0.5
+        irpp = (ptau*ptau + 2*ptau/beta0 + 1)**0.5
         new_rpp = 1./irpp
 
         new_rvv = irpp/(1 + beta0*ptau)
 
-        new_delta =  irpp - 1.
+        new_delta = irpp - 1.
 
         if mask is not None:
             self._delta[mask] = new_delta
@@ -720,6 +719,7 @@ class Particles(xo.HybridClass):
                                         mode='setitem_from_container',
                                         container=self,
                                         container_setitem_name='_ptau_setitem')
+
     @ptau.setter
     def ptau(self, value):
         self.ptau[:] = value
@@ -738,7 +738,7 @@ class Particles(xo.HybridClass):
 
     @property
     def energy0(self):
-        return ( self.p0c * self.p0c + self.mass0 * self.mass0 )**0.5
+        return (self.p0c * self.p0c + self.mass0 * self.mass0)**0.5
 
     @property
     def energy(self):
@@ -760,14 +760,14 @@ class Particles(xo.HybridClass):
 
         ptau_beta0 = (
             delta_energy / self.energy0.copy() +
-            ( delta_beta0 * delta_beta0 + 2.0 * delta_beta0 * beta0
-                    + 1. )**0.5 - 1.)
+            (delta_beta0 * delta_beta0 + 2.0 * delta_beta0 * beta0
+             + 1.)**0.5 - 1.)
 
-        ptau   = ptau_beta0 / beta0
-        delta = ( ptau * ptau + 2. * ptau / beta0 + 1 )**0.5 - 1
+        ptau = ptau_beta0 / beta0
+        delta = (ptau * ptau + 2. * ptau / beta0 + 1)**0.5 - 1
 
         one_plus_delta = delta + 1.
-        rvv = one_plus_delta / ( 1. + ptau_beta0 )
+        rvv = one_plus_delta / (1. + ptau_beta0)
 
         self._delta = delta
         self._ptau = ptau
@@ -792,6 +792,7 @@ def _str_in_list(string, str_list):
             found = True
             break
     return found
+
 
 def part_energy_varnames():
     return [vv for tt, vv in part_energy_vars]
@@ -863,7 +864,7 @@ def gen_local_particle_api(mode='no_local_copy'):
     src_local_to_particles = '\n'.join(src_lines)
 
     # Adders
-    src_lines=[]
+    src_lines = []
     for tt, vv in per_particle_vars:
         src_lines.append('''
     /*gpufun*/
@@ -876,7 +877,7 @@ def gen_local_particle_api(mode='no_local_copy'):
     src_adders = '\n'.join(src_lines)
 
     # Scalers
-    src_lines=[]
+    src_lines = []
     for tt, vv in per_particle_vars:
         src_lines.append('''
     /*gpufun*/
@@ -889,7 +890,7 @@ def gen_local_particle_api(mode='no_local_copy'):
     src_scalers = '\n'.join(src_lines)
 
     # Setters
-    src_lines=[]
+    src_lines = []
     for tt, vv in per_particle_vars:
         src_lines.append('''
     /*gpufun*/
@@ -902,7 +903,7 @@ def gen_local_particle_api(mode='no_local_copy'):
     src_setters = '\n'.join(src_lines)
 
     # Getters
-    src_lines=[]
+    src_lines = []
     for tt, vv in size_vars + scalar_vars:
         src_lines.append('/*gpufun*/')
         src_lines.append(f'{tt._c_type} LocalParticle_get_'+vv
@@ -1184,7 +1185,7 @@ def _pyparticles_to_xpart_dict(pyparticles):
 
         val_py = dct[kk]
 
-        if _num_particles > 1 and len(val_py)==1:
+        if _num_particles > 1 and len(val_py) == 1:
             temp = np.zeros(int(_num_particles), dtype=tt._dtype)
             temp += val_py[0]
             val_py = temp


### PR DESCRIPTION
## Description

This removes `freeze_vars` argument in `particles.gen_local_particle_api`, and replaces it with `#ifndef` guards around the variable setting code to freeze variables. To freeze a variable set `FREEZE_VAR_{var_name}`.

Needs xsuite/xtrack#238.
Part of the solution for xsuite/xsuite#206.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [x] I have tested also GPU contexts
