### PR TITLE
Read in random seeds.

### DIFF
--- a/xpart/particles/_pyparticles.py
+++ b/xpart/particles/_pyparticles.py
@@ -248,6 +248,10 @@ class Pyparticles:
         state = kwargs.get('state', None)  # == 0 particle lost, == 1 particle active
         weight = kwargs.get('weight', None)
         at_element = kwargs.get('at_element', None)
+        _rng_s1 = kwargs.get('_rng_s1', 0)
+        _rng_s2 = kwargs.get('_rng_s2', 0)
+        _rng_s3 = kwargs.get('_rng_s3', 0)
+        _rng_s4 = kwargs.get('_rng_s4', 0)
 
         if mathlib is None:
             mathlib=MathlibDefault
@@ -262,6 +266,10 @@ class Pyparticles:
         self._mass0 = mass0
         self.q0 = q0
         self._update_coordinates = False
+        self._rng_s1 = _rng_s1
+        self._rng_s2 = _rng_s2
+        self._rng_s3 = _rng_s3
+        self._rng_s4 = _rng_s4
 
         if state is not None and not(np.isscalar(state)):
             mask_check = state > -1e8 # Unallocated particles
@@ -502,6 +510,10 @@ class Pyparticles:
         "at_turn",
         "state",
         "weight",
+        "_rng_s1",
+        "_rng_s2",
+        "_rng_s3",
+        "_rng_s4"
     )
 
     def remove_lost_particles(self, keep_memory=True):

--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -214,9 +214,6 @@ class Particles(xo.HybridClass):
                 for tt, kk in list(scalar_vars):
                     setattr(self, kk, part_dict[kk])
                 for tt, kk in list(per_particle_vars):
-                    if kk.startswith('_rng'):
-                        getattr(self, kk)[:] = 0
-                        continue
                     vv = getattr(self, kk)
                     vals =  context.nparray_to_context_array(part_dict[kk])
                     ll = len(vals)
@@ -1280,11 +1277,8 @@ def _pyparticles_to_xpart_dict(pyparticles):
         dct['weight'] = 1.
 
     for tt, kk in scalar_vars + per_particle_vars:
-        if kk.startswith('_rng'):
-            continue
         # Use properties
         dct[kk] = getattr(pyparticles, kk)
-
 
     for kk, vv in dct.items():
         dct[kk] = np.atleast_1d(vv)
@@ -1301,9 +1295,6 @@ def _pyparticles_to_xpart_dict(pyparticles):
         out[kk] = val[0]
 
     for tt, kk in per_particle_vars:
-        if kk.startswith('_rng'):
-            continue
-
         val_py = dct[kk]
 
         if _num_particles > 1 and len(val_py) == 1:


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

A `Particles` object can now be constructed with given seeds for the random generator. This is particularly useful to read in a set of particles from json, where previously the random seeds would be skipped.

Changes are very minimal, just adding property fields and adding it to the dict list in the `PyPyparticles` class, and removing the `continue` statements in the constructor in the `Particles` class.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
