### PR TITLE
Behaves like drift

### DIFF
--- a/tests/test_build_particles_normalized.py
+++ b/tests/test_build_particles_normalized.py
@@ -112,3 +112,58 @@ def test_build_particles_normalized_closed_orbit(test_context):
 
         for nn in 'x px y py zeta delta ptau rvv rpp gamma0 beta0 p0c'.split():
             assert np.allclose(dct[nn], dct_co[nn], atol=1e-15, rtol=0)
+
+
+@for_all_test_contexts
+def test_build_particles_normalized_match_at_s(test_context):
+    for ctx_ref in [test_context, None]:
+        # Build a reference particle
+        p0 = xp.Particles(mass0=xp.PROTON_MASS_EV, q0=1, p0c=7e12, x=1, y=3,
+                          delta=[10], _context=ctx_ref)
+
+        # Load machine model (from pymask)
+        filename = xt._pkg_root.parent.joinpath('test_data/lhc_no_bb/line_and_particle.json')
+        with open(filename, 'r') as fid:
+            input_data = json.load(fid)
+        tracker = xt.Tracker(_context=test_context, line=xt.Line.from_dict(input_data['line']))
+
+        at_element = 'ip6'
+        i_start = tracker.line.element_names.index(at_element)
+        s_start = tracker.line.get_s_position(i_start)
+        # Get the last contigous Drift or Marker after IP6 with non-zero length
+        i = i_start
+        while True:
+            i += 1
+            if tracker.line[i].__class__.__name__ not in ['Drift', 'Marker']:
+                break
+        i_end = i
+        ll = 0
+        while ll==0:
+            i -= 1
+            ll = tracker.line[i].length
+        match_at_s = tracker.line.get_s_position(i) + 0.76*ll
+
+        # Ensure there is a Marker between at_element and match_at_s (to test behave_likes_drift)
+        # TODO: this won't be needed once test lattices contain Markers
+        tracker.line.insert_element(element=xt.Marker, name='test_marker', at_s=s_start + 0.7*(match_at_s-s_start))
+
+        # Built a set of three particles with different x coordinates
+        particles = xp.build_particles(_context=test_context,
+                                       tracker=tracker, particle_ref=p0,
+                                       x=0.02, # in meters
+                                       px_norm=np.random.normal(scale=0.1, size=300), # in sigmas
+                                       y_norm=np.random.normal(scale=0.1, size=300),  # in sigmas
+                                       py_norm=np.random.normal(scale=0.1, size=300), # in sigmas
+                                       zeta=np.random.normal(scale=0.05, size=300),   # in meters
+                                       delta=np.random.normal(scale=1e-4, size=300),
+                                       nemitt_x=3e-6, nemitt_y=3e-6,
+                                       at_element=at_element, match_at_s=match_at_s)
+
+        assert not np.allclose(particles.x, 0.02, atol=1e-5)
+        tracker.line.insert_element(element=xt.Marker, name='match_at_s', at_s=match_at_s)
+        tracker.track(particles, num_elements=(i_start - i_end + 1))
+#         print(particles.at_element)
+#         print(tracker.line[particles.at_element])
+        assert np.allclose(particles.x, 0.02, atol=1e-5)
+
+

--- a/xpart/build_particles.py
+++ b/xpart/build_particles.py
@@ -238,9 +238,8 @@ def build_particles(_context=None, _buffer=None, _offset=None, _capacity=None,
             tracker.line.get_s_elements())<=match_at_s)[0][-1]
         assert at_element == expected_at_element or (
                 at_element < expected_at_element and
-                      all([tracker.line.element_dict[nn].__class__.__name__.startswith('Limit')
-                           or (hasattr(tracker.line.element_dict[nn], 'behaves_like_drift')
-                               and tracker.line.element_dict[nn].behaves_like_drift)
+                      all([ xt._is_aperture(tracker.line.element_dict[nn])
+                           or xt._behaves_like_drift(tracker.line.element_dict[nn])
                 for nn in tracker.line.element_names[at_element:expected_at_element]])), (
             "`match_at_s` can only be placed in the drifts downstream of the "
             "specified `at_element`. No active element can be present in between."

--- a/xpart/build_particles.py
+++ b/xpart/build_particles.py
@@ -238,8 +238,9 @@ def build_particles(_context=None, _buffer=None, _offset=None, _capacity=None,
             tracker.line.get_s_elements())<=match_at_s)[0][-1]
         assert at_element == expected_at_element or (
                 at_element < expected_at_element and
-                      all([isinstance(tracker.line.element_dict[nn], xt.Drift)
-                           or tracker.line.element_dict[nn].__class__.__name__.startswith('Limit')
+                      all([tracker.line.element_dict[nn].__class__.__name__.startswith('Limit')
+                           or (hasattr(tracker.line.element_dict[nn], 'behaves_like_drift')
+                               and tracker.line.element_dict[nn].behaves_like_drift)
                 for nn in tracker.line.element_names[at_element:expected_at_element]])), (
             "`match_at_s` can only be placed in the drifts downstream of the "
             "specified `at_element`. No active element can be present in between."


### PR DESCRIPTION
## Description
 - Allow elements exposing ```behaves_like_drift = True``` in ```build_particles(..., match_at_s=VAL)```.
 - Needs twin pull request in xtrack

Closes # .

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
