### PR TITLE
Feature/backtrack with compile flag

### DIFF
--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -150,7 +150,7 @@ def test_linked_arrays(test_context):
     [
         ('p0c', [4e9, 5e11, 6e13]),
         ('gamma0', [3., 4., 5.]),
-        ('beta0', [0.9, 1.0, 1.1]),
+        ('beta0', [0.8, 0.9, 0.99999999]),
     ]
 )
 def test_particles_update_ref_vars(test_context, varname, values):

--- a/xpart/build_particles.py
+++ b/xpart/build_particles.py
@@ -213,8 +213,8 @@ def build_particles(_context=None, _buffer=None, _offset=None, _capacity=None,
             tw_state = tw.get_twiss_init(at_element=
                 (at_element_line_rmat if at_element_line_rmat is not None else 0))
 
-            # This is not initalized by get_twiss_init
-            tw_state.particle_on_co.at_element = line.element_names.index(
+            # This is not initialized by get_twiss_init
+            tw_state.particle_on_co.at_element = line_rmat.element_names.index(
                                                         tw_state.element_name)
 
             WW = tw_state.W_matrix

--- a/xpart/build_particles.py
+++ b/xpart/build_particles.py
@@ -213,6 +213,10 @@ def build_particles(_context=None, _buffer=None, _offset=None, _capacity=None,
             tw_state = tw.get_twiss_init(at_element=
                 (at_element_line_rmat if at_element_line_rmat is not None else 0))
 
+            # This is not initalized by get_twiss_init
+            tw_state.particle_on_co.at_element = line.element_names.index(
+                                                        tw_state.element_name)
+
             WW = tw_state.W_matrix
             particle_on_co = tw_state.particle_on_co
         elif W_matrix is None and R_matrix is not None:

--- a/xpart/particles/particles_base.py
+++ b/xpart/particles/particles_base.py
@@ -1427,10 +1427,10 @@ class ParticlesBase(xo.HybridClass):
     }
 
     /*gpufun*/
-    void increment_at_element(LocalParticle* part0){
+    void increment_at_element(LocalParticle* part0, int64_t const increment){
 
         //start_per_particle_block (part0->part)
-            LocalParticle_add_to_at_element(part, 1);
+            LocalParticle_add_to_at_element(part, increment);
         //end_per_particle_block
 
     }
@@ -1443,6 +1443,20 @@ class ParticlesBase(xo.HybridClass):
         LocalParticle_set_at_element(part, 0);
         if (flag_reset_s>0){
             LocalParticle_set_s(part, 0.);
+        }
+        //end_per_particle_block
+    }
+
+    /*gpufun*/
+    void increment_at_turn_backtrack(LocalParticle* part0, int flag_reset_s,
+                                     double const line_length,
+                                     int64_t const num_elements){
+
+        //start_per_particle_block (part0->part)
+        LocalParticle_add_to_at_turn(part, -1);
+        LocalParticle_set_at_element(part, num_elements);
+        if (flag_reset_s>0){
+            LocalParticle_set_s(part, line_length);
         }
         //end_per_particle_block
     }

--- a/xpart/particles/particles_base.py
+++ b/xpart/particles/particles_base.py
@@ -787,7 +787,10 @@ class ParticlesBase(xo.HybridClass):
 
                     vv[:n_active] = vv_active
                     vv[n_active:n_active + n_lost] = vv_lost
-                    vv[n_active + n_lost:] = tt._dtype.type(LAST_INVALID_STATE)
+                    if nn.startswith('_rng'):
+                        vv[n_active + n_lost:] = 0
+                    else:
+                        vv[n_active + n_lost:] = tt._dtype.type(LAST_INVALID_STATE)
 
         if isinstance(self._buffer.context, xo.ContextCpu):
             self._num_active_particles = n_active


### PR DESCRIPTION
**Changes:**
 - Change `LocalParticle` methods to allow backtracking without line copies.