### PR TITLE
Fixed initialisation of random generator

### DIFF
--- a/xpart/rng_src/base_rng.h
+++ b/xpart/rng_src/base_rng.h
@@ -28,9 +28,6 @@ double rng_get (uint32_t *s1, uint32_t *s2, uint32_t *s3, uint32_t *s4 ){
 
 /*gpufun*/
 void rng_set (uint32_t *s1, uint32_t *s2, uint32_t *s3, uint32_t *s4, uint32_t s ){
-  if (s == 0)
-    s = 1;      /* default seed is 1 */
-
   *s1 = LCG (s, 69069, 0);
   if (*s1 < 2) *s1 += 2UL;
   *s2 = LCG (*s1, 69069, 0);


### PR DESCRIPTION
There was a line of code in `rng_set` that would overwrite `seed=0` into `seed=1`.
This is not robust, as when one initialises the seeds with a standard range (like [0, ..., 99999]), the first two particles will have the same seed.
