### PR TITLE
fix incorrect behaviour on particle counting with OpenMP

### DIFF
--- a/xpart/particles/particles_base.py
+++ b/xpart/particles/particles_base.py
@@ -1633,8 +1633,8 @@ class ParticlesBase(xo.HybridClass):
             else num_lost++;
         }
         
-        part->_num_active_particles = 1;//num_active;
-        part->_num_lost_particles = 1;//num_lost;
+        part->_num_active_particles = num_active;
+        part->_num_lost_particles = num_lost;
     }
     
     #else // not CPU_SERIAL_IMPLEM and not CPU_OMP_IMPLEM


### PR DESCRIPTION
## Description

When tracking with OpenMP on, the last step of the tracker function is to reorganize particles. This includes a recount of the private fields `_num_active_particles` and `_num_lost_particles`. These were calculated wrong, which had an impact on the collective tracking runs, as in those cases these numbers are important. This fixes the problem.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
