### PR TITLE
Added missing c_name for Particles_initialize_rand_gen

### DIFF
--- a/xpart/particles/particles.py
+++ b/xpart/particles/particles.py
@@ -46,6 +46,7 @@ class Particles(ParticlesBase):
 
     _kernels = {
         'Particles_initialize_rand_gen': xo.Kernel(
+            c_name='Particles_initialize_rand_gen',
             args=[
                 xo.Arg(xo.ThisClass, name='particles'),
                 xo.Arg(xo.UInt32, pointer=True, name='seeds'),


### PR DESCRIPTION
## Description
<!-- Describe why you are making the changes you do
 and link the relevant issues below. -->

A very small change, needed for PR https://github.com/xsuite/xobjects/pull/127

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
