### PR TITLE
Fix issue with zeta convention in multi-bunch beam generation

### DIFF
--- a/tests/test_multi_bunch_gauss_gen.py
+++ b/tests/test_multi_bunch_gauss_gen.py
@@ -92,12 +92,12 @@ def test_multi_bunch_gaussian_generation(test_context):
                     part.zeta[i_bunch*n_part_per_bunch:
                               (i_bunch+1)*n_part_per_bunch]))
                               
-            assert np.isclose((zeta_avg-bunch_spacing*filled_slots[bunch_number])/sigma_z, 0.0, atol=1e-2)
+            assert np.isclose((zeta_avg+bunch_spacing*filled_slots[bunch_number])/sigma_z, 0.0, atol=1e-2)
             assert np.isclose(delta_avg/sigma_delta, 0.0, atol=1e-2)
             assert np.isclose(zeta_rms, sigma_z, rtol=1e-2, atol=1e-15)
             assert np.isclose(delta_rms, sigma_delta, rtol=1e-1, atol=1e-15)
 
-            part_on_co.move(_context=xo.ContextCpu())
+            part_on_co.move(_context=xo.ContextCpu(omp_num_threads=0))
 
             gemitt_x = nemitt_x/part_on_co.beta0/part_on_co.gamma0
             gemitt_y = nemitt_y/part_on_co.beta0/part_on_co.gamma0

--- a/xpart/matched_gaussian.py
+++ b/xpart/matched_gaussian.py
@@ -227,7 +227,7 @@ def generate_matched_gaussian_multibunch_beam(filling_scheme,
     for bunch_number in bunch_numbers:
         bucket_n = filled_buckets[bunch_number]
         macro_bunch.zeta[count * num_particles:
-                         (count+1) * num_particles] += (bunch_spacing *
+                         (count+1) * num_particles] -= (bunch_spacing *
                                                         bucket_n)
         count += 1
 


### PR DESCRIPTION
## Description

We fix an issue with the multi-bunch beam generation.
In the current code the trailing bunches are generated with positive zeta coordinate, while it should be nagative to comply with the xsuite/xfields convention.
We also fix the test accordingly.

## Checklist

Mandatory: 

- [x] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
