### PR TITLE
Fixes for Scipy 1.14.0

### DIFF
--- a/xpart/longitudinal/pdf_integrators_2d.py
+++ b/xpart/longitudinal/pdf_integrators_2d.py
@@ -10,7 +10,13 @@
 '''
 
 import numpy as np
-from scipy.integrate import quad, dblquad, cumtrapz, romb
+from scipy.integrate import dblquad, romb
+
+try:
+    from scipy.integrate import cumulative_trapezoid
+    cumtrapz = cumulative_trapezoid
+except ImportError:
+    from scipy.integrate import cumtrapz  # removed in scipy>=1.14.0
 
 
 def quad2d(f, ylimits, xmin, xmax):


### PR DESCRIPTION
## Description

Following the new release of numpy 2.0 there is a new release of scipy 1.14 that removes some previously deprecated functionality: https://github.com/scipy/scipy/releases/tag/v1.14.0. This PR updates xpart to be compatible with these changes.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
