### PR TITLE
Update pencil.py

### DIFF
--- a/xpart/transverse_generators/pencil.py
+++ b/xpart/transverse_generators/pencil.py
@@ -89,7 +89,7 @@ def generate_2D_pencil(num_particles, pos_cut_sigmas, dr_sigmas,
 def generate_2D_pencil_with_absolute_cut(num_particles,
     plane, absolute_cut, dr_sigmas, side='+', tracker=None, line=None,
     nemitt_x=None, nemitt_y=None,
-    at_element=None, match_at_s=None, **kwargs):
+    at_element=None, match_at_s=None, tw_at_s=None, **kwargs):
 
     '''
     Generate a 2D pencil beam distribution with an absolute cut.
@@ -151,9 +151,10 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
     else:
         drift_to_at_s = None
 
-    tw_at_s = line.twiss(at_s=match_at_s,
-        at_elements=([at_element] if match_at_s is None else None),
-        **kwargs)
+    if tw_at_s is None:
+        tw_at_s = line.twiss(at_s=match_at_s,
+            at_elements=([at_element] if match_at_s is None else None),
+            **kwargs)
 
     if side=='+':
         assert tw_at_s[plane][0] < absolute_cut, 'The cut is on the wrong side'

--- a/xpart/transverse_generators/pencil.py
+++ b/xpart/transverse_generators/pencil.py
@@ -89,7 +89,7 @@ def generate_2D_pencil(num_particles, pos_cut_sigmas, dr_sigmas,
 def generate_2D_pencil_with_absolute_cut(num_particles,
     plane, absolute_cut, dr_sigmas, side='+', tracker=None, line=None,
     nemitt_x=None, nemitt_y=None,
-    at_element=None, match_at_s=None, tw=None, **kwargs):
+    at_element=None, match_at_s=None, twiss=None, **kwargs):
 
     '''
     Generate a 2D pencil beam distribution with an absolute cut.
@@ -151,8 +151,8 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
     else:
         drift_to_at_s = None
 
-    if tw is None:
-        tw = line.twiss(at_s=match_at_s,
+    if twiss is None:
+        twiss = line.twiss(at_s=match_at_s,
             at_elements=([at_element] if match_at_s is None else None),
             **kwargs)
 
@@ -178,7 +178,7 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
         p_on_cut_at_s = p_on_cut_at_element
 
     # Get cut in (accurate) sigmas
-    p_on_cut_norm = tw.get_normalized_coordinates(p_on_cut_at_s,
+    p_on_cut_norm = twiss.get_normalized_coordinates(p_on_cut_at_s,
                                         nemitt_x=nemitt_x, nemitt_y=nemitt_y,
                                         _force_at_element=0 # the twiss has only this element
                                         )

--- a/xpart/transverse_generators/pencil.py
+++ b/xpart/transverse_generators/pencil.py
@@ -89,7 +89,7 @@ def generate_2D_pencil(num_particles, pos_cut_sigmas, dr_sigmas,
 def generate_2D_pencil_with_absolute_cut(num_particles,
     plane, absolute_cut, dr_sigmas, side='+', tracker=None, line=None,
     nemitt_x=None, nemitt_y=None,
-    at_element=None, match_at_s=None, tw_at_s=None, **kwargs):
+    at_element=None, match_at_s=None, tw=None, **kwargs):
 
     '''
     Generate a 2D pencil beam distribution with an absolute cut.
@@ -151,15 +151,15 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
     else:
         drift_to_at_s = None
 
-    if tw_at_s is None:
-        tw_at_s = line.twiss(at_s=match_at_s,
+    if tw is None:
+        tw = line.twiss(at_s=match_at_s,
             at_elements=([at_element] if match_at_s is None else None),
             **kwargs)
 
     if side=='+':
-        assert tw_at_s[plane][0] < absolute_cut, 'The cut is on the wrong side'
+        assert tw[plane][0] < absolute_cut, 'The cut is on the wrong side'
     else:
-        assert tw_at_s[plane][0] > absolute_cut, 'The cut is on the wrong side'
+        assert tw[plane][0] > absolute_cut, 'The cut is on the wrong side'
 
     # Generate a particle exactly on the jaw with no amplitude in other eigemvectors
     p_on_cut_at_element = line.build_particles(
@@ -178,7 +178,7 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
         p_on_cut_at_s = p_on_cut_at_element
 
     # Get cut in (accurate) sigmas
-    p_on_cut_norm = tw_at_s.get_normalized_coordinates(p_on_cut_at_s,
+    p_on_cut_norm = tw.get_normalized_coordinates(p_on_cut_at_s,
                                         nemitt_x=nemitt_x, nemitt_y=nemitt_y,
                                         _force_at_element=0 # the twiss has only this element
                                         )


### PR DESCRIPTION
Added tw_at_s as a parameter.
This makes generate_pencil_on_collimator in xcoll a lot faster.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
