### PR TITLE
4D round q-Gaussian generator 

### DIFF
--- a/examples/particles_generation/008_generate_q_gaussian.py
+++ b/examples/particles_generation/008_generate_q_gaussian.py
@@ -1,0 +1,91 @@
+# copyright ############################### #
+# This file is part of the Xpart Package.   #
+# Copyright (c) CERN, 2021.                 #
+# ######################################### #
+
+import json
+import numpy as np
+from matplotlib import pyplot as plt
+import xpart as xp
+import xtrack as xt
+
+
+def q_gaussian_1d(x, q, beta, normalize=False):
+    """
+
+    Args:
+        x:
+        q: q-parameter
+        beta: beta for q-Gaussian
+        normalize: if normalize area to 1
+
+    Returns:
+        q-Gaussian function defined on x
+
+    """
+    assert q < 3, "q must be less than 3 for normalizability"
+    # Compute the argument of the power
+    arg = 1 - (1 - q) * beta * x**2
+    # Set values outside domain to 0
+    f = np.where(arg > 0, arg**(1 / (1 - q)), 0)
+    if normalize:
+        dx = x[1] - x[0]
+        area = np.sum(f) * dx
+        f /= area
+    return f
+
+
+bunch_intensity = 1e11
+sigma_z = 22.5e-2
+n_part = int(5e5)
+nemitt_x = 2e-6
+nemitt_y = 2.5e-6
+
+filename = ('../../../xtrack/test_data/sps_w_spacecharge'
+            '/line_no_spacecharge_and_particle.json')
+with open(filename, 'r') as fid:
+    ddd = json.load(fid)
+line = xt.Line.from_dict(ddd['line'])
+line.particle_ref = xp.Particles.from_dict(ddd['particle'])
+
+line.build_tracker()
+
+q = 1.1
+beta = 0.6
+
+x_norm, px_norm, y_norm, py_norm = xp.generate_round_4D_qgaussian_normalised(q=q, beta=beta, n_part=int(1e6))
+
+
+x = np.linspace(-10, 10, 1000)
+f = q_gaussian_1d(x, q, beta, normalize=True)
+
+
+# PLOT normalised x against 1D q-Gaussian
+plt.plot(x, f, color='blue', label=f'1D q-Gaussian q={q}, beta={beta}')
+plt.hist(x_norm, bins=100, density=True, label=f'sampled q-Gaussian q={q}, beta={beta}')
+plt.legend()
+plt.show()
+
+
+
+particles = line.build_particles(
+                               zeta=0, delta=1e-3,
+                               x_norm=x_norm, # in sigmas
+                               px_norm=px_norm, # in sigmas
+                               y_norm=y_norm,
+                               py_norm=py_norm,
+                               nemitt_x=3e-6, nemitt_y=3e-6)
+
+# CHECKS
+
+y_rms = np.std(particles.y)
+py_rms = np.std(particles.py)
+x_rms = np.std(particles.x)
+px_rms = np.std(particles.px)
+
+
+
+
+
+
+

--- a/examples/particles_generation/008_generate_q_gaussian.py
+++ b/examples/particles_generation/008_generate_q_gaussian.py
@@ -12,7 +12,6 @@ import xtrack as xt
 
 def q_gaussian_1d(x, q, beta, normalize=False):
     """
-
     Args:
         x:
         q: q-parameter
@@ -50,23 +49,21 @@ line.particle_ref = xp.Particles.from_dict(ddd['particle'])
 
 line.build_tracker()
 
-q = 1.1
-beta = 0.6
+q = 1.2
+beta = 1
 
-x_norm, px_norm, y_norm, py_norm = xp.generate_round_4D_qgaussian_normalised(q=q, beta=beta, n_part=int(1e6))
+x_norm, px_norm, y_norm, py_norm = xp.generate_round_4D_q_gaussian_normalised(q=q, beta=beta, n_part=int(1e6))
 
 
-x = np.linspace(-10, 10, 1000)
+x = np.linspace(-5, 5, 4000)
 f = q_gaussian_1d(x, q, beta, normalize=True)
 
 
 # PLOT normalised x against 1D q-Gaussian
 plt.plot(x, f, color='blue', label=f'1D q-Gaussian q={q}, beta={beta}')
-plt.hist(x_norm, bins=100, density=True, label=f'sampled q-Gaussian q={q}, beta={beta}')
+plt.hist(x_norm, bins=200, density=True, label=f'sampled q-Gaussian q={q}, beta={beta}')
 plt.legend()
 plt.show()
-
-
 
 particles = line.build_particles(
                                zeta=0, delta=1e-3,
@@ -77,11 +74,12 @@ particles = line.build_particles(
                                nemitt_x=3e-6, nemitt_y=3e-6)
 
 # CHECKS
-
 y_rms = np.std(particles.y)
 py_rms = np.std(particles.py)
 x_rms = np.std(particles.x)
 px_rms = np.std(particles.px)
+
+print('y rms: ', y_rms, 'py rms: ', py_rms,'x rms: ', x_rms, 'px rms: ', px_rms)
 
 
 

--- a/xpart/__init__.py
+++ b/xpart/__init__.py
@@ -22,7 +22,7 @@ from .transverse_generators import generate_2D_pencil_with_absolute_cut
 from .transverse_generators import generate_2D_gaussian
 from .transverse_generators import (generate_hypersphere_2D, generate_hypersphere_4D,
                                     generate_hypersphere_6D)
-from .transverse_generators import generate_round_4D_qgaussian_normalised
+from .transverse_generators import generate_round_4D_q_gaussian_normalised
 
 from .longitudinal import generate_longitudinal_coordinates
 from .longitudinal.generate_longitudinal import _characterize_line

--- a/xpart/__init__.py
+++ b/xpart/__init__.py
@@ -22,6 +22,7 @@ from .transverse_generators import generate_2D_pencil_with_absolute_cut
 from .transverse_generators import generate_2D_gaussian
 from .transverse_generators import (generate_hypersphere_2D, generate_hypersphere_4D,
                                     generate_hypersphere_6D)
+from .transverse_generators import generate_round_4D_qgaussian_normalised
 
 from .longitudinal import generate_longitudinal_coordinates
 from .longitudinal.generate_longitudinal import _characterize_line

--- a/xpart/transverse_generators/__init__.py
+++ b/xpart/transverse_generators/__init__.py
@@ -8,3 +8,4 @@ from .polar import generate_2D_uniform_circular_sector
 from .pencil import generate_2D_pencil, generate_2D_pencil_with_absolute_cut
 from .gaussian import generate_2D_gaussian
 from .hypersphere import generate_hypersphere_2D, generate_hypersphere_4D, generate_hypersphere_6D
+from .q_gaussian_round import generate_round_4D_qgaussian_normalised

--- a/xpart/transverse_generators/__init__.py
+++ b/xpart/transverse_generators/__init__.py
@@ -8,4 +8,4 @@ from .polar import generate_2D_uniform_circular_sector
 from .pencil import generate_2D_pencil, generate_2D_pencil_with_absolute_cut
 from .gaussian import generate_2D_gaussian
 from .hypersphere import generate_hypersphere_2D, generate_hypersphere_4D, generate_hypersphere_6D
-from .q_gaussian_round import generate_round_4D_qgaussian_normalised
+from .q_gaussian_round import generate_round_4D_q_gaussian_normalised

--- a/xpart/transverse_generators/q_gaussian_round.py
+++ b/xpart/transverse_generators/q_gaussian_round.py
@@ -18,7 +18,7 @@ def generate_radial_distribution(q, beta):
     Compute the 4D radial distribution function for a round q-Gaussian.
 
     Parameters:
-        q (float): Entropic index (q > 1).
+        q (float): q-parameter (q > 1).
         beta (float): Scale parameter.
 
     Returns:
@@ -66,16 +66,7 @@ def generate_CDF(g_F, F):
     """
     return np.cumsum(
         np.diff(np.insert(F, 0, 0)) * g_F
-    )  # fast cumulative trapezoid approx
-
-
-# Functions for random sampling in 4D
-def random_beta(F_G):
-    for i in range(len(F_G)):
-        beta_x = np.random.uniform(0, 2 * np.pi, 1)
-        beta_y = np.random.uniform(0, 2 * np.pi, 1)
-    return beta_x, beta_y
-
+    )
 
 def sample_from_inv_cdf(Np, cdf_g, F):
     """

--- a/xpart/transverse_generators/q_gaussian_round.py
+++ b/xpart/transverse_generators/q_gaussian_round.py
@@ -1,0 +1,145 @@
+#################################################
+# This code randomly samples 4D                 #
+# q-Gaussian distributions (q>1) using the      #
+# methods of Batygin                            #
+# https://doi.org/10.1016/j.nima.2004.10.029    #
+# and the 4D q-Gaussian formula derived in      #
+# https://cds.cern.ch/record/2912366?ln=en      #
+#################################################
+
+
+import numpy as np
+from scipy.special import gamma
+from scipy.interpolate import interp1d
+
+
+def generate_radial_distribution(q, beta):
+    """
+    Compute the 4D radial distribution function for a round q-Gaussian.
+
+    Parameters:
+        q (float): Entropic index (q > 1).
+        beta (float): Scale parameter.
+
+    Returns:
+        tuple: (f_F, F) where f_F is the radial distribution, and F is the radial coordinate array.
+    """
+    assert q > 1, "q must be greater than 1"
+    F = np.linspace(0, 3000, 100000)
+    term1 = -(beta**2) * (q - 3) * (q**2 - 1) / 4 / np.pi**2
+    if q < 1.01:
+        term2 = -1 / (1 - q)
+    else:
+        term2 = gamma(q / (q - 1)) / gamma(1 / (q - 1))
+
+    term3 = (1 + beta * (q - 1) * F) ** (1 / (1 - q) - 3 / 2)
+    return term1 * term2 * term3, F
+
+
+def generate_PDF(f_F, F):
+    """
+    Compute the PDF g(F) from f(F) using the Abel transform in 4D.
+
+    Parameters:
+        f_F (np.ndarray): Distribution array.
+        F (np.ndarray): Radial coordinate array.
+
+    Returns:
+        np.ndarray: Transformed PDF g(F).
+    """
+    f_F[0] = 0
+    f_F[-1] = 0
+    g_F = np.pi**2 * f_F * F
+    return g_F
+
+
+def generate_CDF(g_F, F):
+    """
+    Compute the cumulative distribution function (CDF) of g(F).
+
+    Parameters:
+        g_F (np.ndarray): PDF values.
+        F (np.ndarray): Radial coordinates.
+
+    Returns:
+        np.ndarray: CDF of g(F).
+    """
+    return np.cumsum(
+        np.diff(np.insert(F, 0, 0)) * g_F
+    )  # fast cumulative trapezoid approx
+
+
+# Functions for random sampling in 4D
+def random_beta(F_G):
+    for i in range(len(F_G)):
+        beta_x = np.random.uniform(0, 2 * np.pi, 1)
+        beta_y = np.random.uniform(0, 2 * np.pi, 1)
+    return beta_x, beta_y
+
+
+def sample_from_inv_cdf(Np, cdf_g, F):
+    """
+    Sample F values from the inverse CDF of g(F).
+
+    Parameters:
+        Np (int): Number of particles to sample.
+        cdf_g (np.ndarray): CDF of g(F).
+        F (np.ndarray): Original F grid.
+
+    Returns:
+        np.ndarray: Sampled F values (F_G).
+    """
+    cdf_g /= cdf_g[-1]  # normalize
+    uniform_samples = np.random.uniform(0, 1, Np)
+    interpolator = interp1d(
+        cdf_g, F, kind="nearest", bounds_error=False, fill_value=(F[0], F[-1])
+    )
+    return interpolator(uniform_samples)
+
+
+def generate_random_A(F_G):
+    """
+    Generate A_x and A_y coordinates based on F_G distribution.
+
+    Parameters:
+        F_G (np.ndarray): Sampled F values.
+
+    Returns:
+        tuple: (A_x, A_y) arrays.
+    """
+    A_X_SQ = np.random.uniform(0, F_G)
+    A_x = np.sqrt(A_X_SQ)
+    A_y = np.sqrt(F_G - A_X_SQ)
+    return A_x, A_y
+
+
+# function to generate a round 4D q-Gaussian
+def generate_round_4D_qgaussian_normalised(q, beta, n_part):
+    """
+    Generate particles sampled from a 4D round q-Gaussian distribution.
+
+    Parameters:
+        q (float): q-Gaussian q parameter.
+        beta (float): Scale parameter.
+        n_part (int): Number of particles to sample.
+
+    Returns:
+        tuple: Arrays of positions and momenta (x, px, y, py).
+    """
+    f_F, F = generate_radial_distribution(q, beta)  # 4D distribution
+    g_F = generate_PDF(f_F, F)  # PDF of 4D distribution
+    cdf_g = generate_CDF(g_F, F)  # CDF
+    F_G = sample_from_inv_cdf(n_part, cdf_g, F)  # Inverse function
+    A_x, A_y = generate_random_A(F_G)  # random generator distributed like F_G
+
+    # Sample angles for all particles
+    beta_x = np.random.uniform(0, 2 * np.pi, n_part)
+    beta_y = np.random.uniform(0, 2 * np.pi, n_part)
+
+    # Compute positions and momenta
+    x = A_x * np.cos(beta_x)
+    px = -A_x * np.sin(beta_x)
+    y = -A_y * np.cos(beta_y)
+    py = -A_y * np.sin(beta_y)
+
+    return x, px, y, py

--- a/xpart/transverse_generators/q_gaussian_round.py
+++ b/xpart/transverse_generators/q_gaussian_round.py
@@ -1,7 +1,7 @@
 #################################################
 # This code randomly samples 4D                 #
 # q-Gaussian distributions (q>1) using the      #
-# methods of Batygin                            #
+# samplign methods of Batygin                   #
 # https://doi.org/10.1016/j.nima.2004.10.029    #
 # and the 4D q-Gaussian formula derived in      #
 # https://cds.cern.ch/record/2912366?ln=en      #


### PR DESCRIPTION
## Description
Adds 4D q-gaussian generator to create normalised coordinates in 4D.
Beam is round and q is the same in x and y.
Example in xpart/examples/particles_generation/008_generate_q_gaussian.py

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x ] I described my changes in this PR description

Optional:

- [x ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
