### PR TITLE
Small bugfix: only a single element should be passed to `pos_cut_sigmas`

### DIFF
--- a/xpart/transverse_generators/pencil.py
+++ b/xpart/transverse_generators/pencil.py
@@ -184,9 +184,9 @@ def generate_2D_pencil_with_absolute_cut(num_particles,
                                         _force_at_element=0 # the twiss has only this element
                                         )
     if plane == 'x':
-        pencil_cut_sigmas = np.abs(p_on_cut_norm.x_norm)
+        pencil_cut_sigmas = np.abs(p_on_cut_norm.x_norm)[0]
     else:
-        pencil_cut_sigmas = np.abs(p_on_cut_norm.y_norm)
+        pencil_cut_sigmas = np.abs(p_on_cut_norm.y_norm)[0]
 
     # Generate normalized pencil in the selected plane (here w is x or y according to plane)
     w_in_sigmas, pw_in_sigmas, r_points, theta_points = xp.generate_2D_pencil(


### PR DESCRIPTION
Small bugfix: only a single element should be passed to `pos_cut_sigmas`.

Otherwise, the cast to `int`:
https://github.com/xsuite/xpart/blob/39a36e0eb48387df178c0fdc9031cea36ba8db16/xpart/transverse_generators/pencil.py#L62
will fail in the latest numpy. This was deprecated with a warning since numpy 1.25.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [X] All the tests are passing, including my new ones
- [X] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
